### PR TITLE
Disable Dark mode

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -14,10 +14,3 @@ body {
   --background: #ffffff;
   --foreground: #171717;
 }
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}


### PR DESCRIPTION
Here are screenshots with this change:

**Photo Gallery**
<img width="3265" height="2084" alt="image" src="https://github.com/user-attachments/assets/4ff04108-f2cc-4b66-9afc-76c1376da60b" />

**Login Page**
<img width="3265" height="2084" alt="image" src="https://github.com/user-attachments/assets/646a9f72-fa8c-44f9-b2be-04e0dfa8cb0f" />
*Note: the issue in the bottom left is caused by a grammar checker extension that I have installed. It is the dev tool flagging that the client contents don't match the server contents, which is due to the HTML added by my extension. This is not an issue.*